### PR TITLE
[Migration Agent] Upgrade @angular-devkit/build-angular, @angular/animations, @angular/cli, @angular/common, @angular/compiler, @angular/compiler-cli, @angular/core, @angular/forms, @angular/platform-browser, @angular/platform-browser-dynamic, @angular/router, uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "code-migration-node",
+  "version": "0.0.0",
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "watch": "ng build --watch --configuration development",
+    "test": "ng test"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/animations": "^18.2.0",
+    "@angular/common": "^18.2.0",
+    "@angular/compiler": "^18.2.0",
+    "@angular/core": "^18.2.0",
+    "@angular/forms": "^18.2.0",
+    "@angular/platform-browser": "^18.2.0",
+    "@angular/platform-browser-dynamic": "^18.2.0",
+    "@angular/router": "^18.2.0",
+    "rxjs": "~7.8.0",
+    "tslib": "^2.3.0",
+    "uuid": "^11.0.0",
+    "zone.js": "~0.14.3"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^18.2.0",
+    "@angular/cli": "^18.2.0",
+    "@angular/compiler-cli": "^18.2.0",
+    "@types/jasmine": "~5.1.0",
+    "jasmine-core": "~5.1.0",
+    "karma": "~6.4.0",
+    "karma-chrome-launcher": "~3.2.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "typescript": "~5.5.2"
+  }
+}


### PR DESCRIPTION
## Dependency Upgrades

This PR upgrades the following dependencies to their latest available versions:

### Angular Ecosystem (17.x → 18.2.x)

All Angular packages have been upgraded together to maintain version consistency across the framework:

| Package | Old Version | New Version |
|---|---|---|
| `@angular/animations` | `^17.3.0` | `^18.2.0` |
| `@angular/common` | `^17.3.0` | `^18.2.0` |
| `@angular/compiler` | `^17.3.0` | `^18.2.0` |
| `@angular/core` | `^17.3.0` | `^18.2.0` |
| `@angular/forms` | `^17.3.0` | `^18.2.0` |
| `@angular/platform-browser` | `^17.3.0` | `^18.2.0` |
| `@angular/platform-browser-dynamic` | `^17.3.0` | `^18.2.0` |
| `@angular/router` | `^17.3.0` | `^18.2.0` |
| `@angular-devkit/build-angular` | `^17.3.17` | `^18.2.0` |
| `@angular/cli` | `^17.3.17` | `^18.2.0` |
| `@angular/compiler-cli` | `^17.3.0` | `^18.2.0` |

### Other Dependencies

| Package | Old Version | New Version |
|---|---|---|
| `uuid` | `^3.4.0` | `^11.0.0` |

### TypeScript

TypeScript has been updated from `~5.4.2` to `~5.5.2` to satisfy Angular 18's peer dependency requirement (`>=5.4.0 <5.6.0`).

---

### ⚠️ Breaking Changes & Migration Notes

#### Angular 17 → 18
- **Zone.js**: Angular 18 introduces experimental zoneless support; the existing `zone.js` version (`~0.14.3`) remains compatible.
- **`@angular/platform-browser-dynamic`**: The `BrowserModule.withServerTransition()` API has been removed. If used, migrate to the new bootstrapping flow.
- **Required Inputs**: Angular 18 enforces stricter checks on required inputs at compile time.
- **Lazy routes**: Router lazy-loading API changes may require review if using deprecated patterns.
- Run `ng update @angular/core@18 @angular/cli@18` after installing to apply any automatic migrations.

#### uuid 3.x → 11.x
- **ESM-only**: `uuid` v11 is ESM-only. If the project uses CommonJS imports (`const { v4 } = require('uuid')`), these must be changed to ES module imports (`import { v4 as uuidv4 } from 'uuid'`).
- **API**: The core `v1`, `v3`, `v4`, `v5` functions remain but are now named exports only; the default export has been removed.
- **Node.js**: Requires Node.js 16 or higher.
- **`@types/uuid`**: The `@types/uuid` package is no longer needed as `uuid` v11 ships its own TypeScript types. Remove it from `devDependencies` if present.

### Testing

After upgrading, run the full test suite to verify compatibility:
```bash
npm install
ng build
ng test
```