### PR TITLE
[Migration Agent] Upgrade uuid, @angular-devkit/build-angular, @angular/animations and 9 more

### DIFF
--- a/angular-app/package.json
+++ b/angular-app/package.json
@@ -10,30 +10,29 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^17.3.0",
-    "@angular/common": "^17.3.0",
-    "@angular/compiler": "^17.3.0",
-    "@angular/core": "^17.3.0",
-    "@angular/forms": "^17.3.0",
-    "@angular/platform-browser": "^17.3.0",
-    "@angular/platform-browser-dynamic": "^17.3.0",
-    "@angular/router": "^17.3.0",
+    "@angular/animations": "^19.2.0",
+    "@angular/common": "^19.2.0",
+    "@angular/compiler": "^19.2.0",
+    "@angular/core": "^19.2.0",
+    "@angular/forms": "^19.2.0",
+    "@angular/platform-browser": "^19.2.0",
+    "@angular/platform-browser-dynamic": "^19.2.0",
+    "@angular/router": "^19.2.0",
     "axios": "0.19.0",
     "express": "4.17.1",
     "lodash": "4.17.15",
     "moment": "2.24.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "uuid": "3.4.0",
-    "zone.js": "~0.14.3"
+    "uuid": "^11.1.0",
+    "zone.js": "~0.15.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^17.3.17",
-    "@angular/cli": "^17.3.17",
-    "@angular/compiler-cli": "^17.3.0",
+    "@angular-devkit/build-angular": "^19.2.0",
+    "@angular/cli": "^19.2.0",
+    "@angular/compiler-cli": "^19.2.0",
     "@types/jasmine": "~5.1.0",
     "@types/lodash": "^4.17.24",
-    "@types/moment": "^2.11.29",
     "@types/uuid": "^10.0.0",
     "jasmine-core": "~5.1.0",
     "karma": "~6.4.0",
@@ -41,6 +40,6 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.2"
   }
 }


### PR DESCRIPTION
## Dependency Fix: Remove deprecated `@types/moment` package

### Changes

#### `angular-app/package.json`
- **Removed** `@types/moment` from `devDependencies`.
  - `moment` 2.x ships its own bundled TypeScript declarations and the separate `@types/moment` package is officially deprecated. Including both causes type conflicts and compiler warnings. Moment's own types are sufficient and automatically picked up by TypeScript.

### No Changes Required
- **`app.component.ts`**: The `import moment from 'moment'` syntax is fully compatible with moment's bundled types — no source changes needed.
- **`uuid` v11 import**: The `import { v4 as uuidv4 } from 'uuid'` named import remains valid in uuid v11; no changes required.
- **SQLAlchemy / Pillow / cryptography**: These errors relate to Python backend files not present in the Angular workspace and are out of scope for this changeset.